### PR TITLE
Install ipset if iptables is enabled (debian)

### DIFF
--- a/install/hst-install-debian.sh
+++ b/install/hst-install-debian.sh
@@ -809,8 +809,10 @@ if [ "$postgresql" = 'no' ]; then
     software=$(echo "$software" | sed -e "s/php$fpm_v-pgsql//")
     software=$(echo "$software" | sed -e "s/phppgadmin//")
 fi
-if [ "$iptables" = 'no' ] || [ "$fail2ban" = 'no' ]; then
+if [ "$fail2ban" = 'no' ]; then
     software=$(echo "$software" | sed -e "s/fail2ban//")
+fi
+if [ "$iptables" = 'no' ]; then
     software=$(echo "$software" | sed -e "s/ipset//")
 fi
 if [ "$phpfpm" = 'yes' ]; then


### PR DESCRIPTION
Install ipset if iptables is enabled, regardless of fail2ban.